### PR TITLE
fix compiler warnings format-truncation and unused-but-set-variable

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -82,7 +82,9 @@ void Log::applog(const int priority, const char *fmt, ...) {
 		// cut line to insert nsec '.000000000'
 		ascTime[19] = 0;
 		char time[150];
-		snprintf(time, sizeof(time), "%s.%04lu %s", &ascTime[0], time_stamp.tv_nsec/100000, &ascTime[20]);
+		if (snprintf(time, sizeof(time), "%s.%04lu %s", &ascTime[0], time_stamp.tv_nsec/100000, &ascTime[20]) < 0) {
+			continue;
+		};
 		elem.timestamp = time;
 
 		// set message

--- a/src/socket/TcpSocket.cpp
+++ b/src/socket/TcpSocket.cpp
@@ -51,11 +51,6 @@ void TcpSocket::initialize(const std::string &ipAddr, int port, bool nonblock) {
 		_pfd[0].events = POLLIN | POLLHUP | POLLRDNORM | POLLERR;
 		_pfd[0].revents = 0;
 
-		struct pollfd pfdNew;
-		pfdNew.fd = _server.getFD();
-		pfdNew.events = POLLIN | POLLHUP | POLLRDNORM | POLLERR;
-		pfdNew.revents = 0;
-
 		for (std::size_t i = 1; i < _MAX_POLL; ++i) {
 			_pfd[i].fd = -1;
 			_pfd[i].events = POLLIN | POLLHUP | POLLRDNORM | POLLERR;


### PR DESCRIPTION
see https://stackoverflow.com/questions/51534284/how-to-circumvent-format-truncation-warning-in-gcc about the warning issue with ```snprintf```