### PR TITLE
FreeBSD and clang support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ###############################################################################
 
 # Set the compiler being used.
-CXX = $(CXXPREFIX)g++$(CXXSUFFIX)
+CXX ?= $(CXXPREFIX)g++$(CXXSUFFIX)
 
 # Check compiler support for some functions
 RESULT_HAS_NP_FUNCTIONS := $(shell $(CXX) -o npfunc checks/npfunc.cpp -pthread 2> /dev/null ; echo $$? ; rm -rf npfunc)

--- a/src/base/Thread.cpp
+++ b/src/base/Thread.cpp
@@ -29,7 +29,10 @@
 #define _GNU_SOURCE _GNU_SOURCE
 #endif
 
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif
+
 #include <unistd.h>
 
 namespace base {

--- a/src/base/Thread.cpp
+++ b/src/base/Thread.cpp
@@ -29,7 +29,7 @@
 #define _GNU_SOURCE _GNU_SOURCE
 #endif
 
-#ifdef __linux__
+#ifndef HAS_NP_FUNCTIONS
 #include <sys/prctl.h>
 #endif
 

--- a/src/base/Thread.h
+++ b/src/base/Thread.h
@@ -26,7 +26,10 @@
 
 #include <pthread.h>
 #include <unistd.h>
+
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif
 
 namespace base {
 

--- a/src/base/Thread.h
+++ b/src/base/Thread.h
@@ -27,7 +27,7 @@
 #include <pthread.h>
 #include <unistd.h>
 
-#ifdef __linux__
+#ifndef HAS_NP_FUNCTIONS
 #include <sys/prctl.h>
 #endif
 

--- a/src/base/ThreadBase.cpp
+++ b/src/base/ThreadBase.cpp
@@ -28,7 +28,7 @@
 #define _GNU_SOURCE _GNU_SOURCE
 #endif
 
-#ifdef __linux__
+#ifndef HAS_NP_FUNCTIONS
 #include <sys/prctl.h>
 #endif
 

--- a/src/base/ThreadBase.cpp
+++ b/src/base/ThreadBase.cpp
@@ -28,7 +28,10 @@
 #define _GNU_SOURCE _GNU_SOURCE
 #endif
 
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif
+
 #include <unistd.h>
 
 namespace base {

--- a/src/mpegts/Filter.cpp
+++ b/src/mpegts/Filter.cpp
@@ -50,7 +50,7 @@ namespace mpegts {
 
 	void Filter::addData(const int streamID, const mpegts::PacketBuffer &buffer) {
 		base::MutexLock lock(_mutex);
-		static std::size_t size = buffer.getNumberOfTSPackets();
+		static constexpr std::size_t size = mpegts::PacketBuffer::getNumberOfTSPackets();
 		for (std::size_t i = 0; i < size; ++i) {
 			const unsigned char *ptr = buffer.getTSPacketPtr(i);
 			// Check is this the beginning of the TS and no Transport error indicator

--- a/src/mpegts/Filter.cpp
+++ b/src/mpegts/Filter.cpp
@@ -50,7 +50,7 @@ namespace mpegts {
 
 	void Filter::addData(const int streamID, const mpegts::PacketBuffer &buffer) {
 		base::MutexLock lock(_mutex);
-		static constexpr std::size_t size = buffer.getNumberOfTSPackets();
+		static std::size_t size = buffer.getNumberOfTSPackets();
 		for (std::size_t i = 0; i < size; ++i) {
 			const unsigned char *ptr = buffer.getTSPacketPtr(i);
 			// Check is this the beginning of the TS and no Transport error indicator

--- a/src/output/StreamThreadHttp.cpp
+++ b/src/output/StreamThreadHttp.cpp
@@ -72,7 +72,7 @@ int StreamThreadHttp::getStreamSocketPort(const int clientID) const {
 }
 
 bool StreamThreadHttp::writeDataToOutputDevice(mpegts::PacketBuffer &buffer, StreamClient &client) {
-	static unsigned int dataSize = buffer.getBufferSize();
+	static constexpr unsigned int dataSize = mpegts::PacketBuffer::getBufferSize();
 	const long timestamp = base::TimeCounter::getTicks() * 90;
 
 	// RTP packet octet count (Bytes)

--- a/src/output/StreamThreadHttp.cpp
+++ b/src/output/StreamThreadHttp.cpp
@@ -28,6 +28,10 @@
 #include <chrono>
 #include <thread>
 
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
 namespace output {
 
 // =========================================================================

--- a/src/output/StreamThreadHttp.cpp
+++ b/src/output/StreamThreadHttp.cpp
@@ -72,7 +72,7 @@ int StreamThreadHttp::getStreamSocketPort(const int clientID) const {
 }
 
 bool StreamThreadHttp::writeDataToOutputDevice(mpegts::PacketBuffer &buffer, StreamClient &client) {
-	static constexpr unsigned int dataSize = buffer.getBufferSize();
+	static unsigned int dataSize = buffer.getBufferSize();
 	const long timestamp = base::TimeCounter::getTicks() * 90;
 
 	// RTP packet octet count (Bytes)

--- a/src/output/StreamThreadRtcp.cpp
+++ b/src/output/StreamThreadRtcp.cpp
@@ -25,6 +25,8 @@
 
 #include <cstring>
 
+#include <sys/socket.h>
+
 namespace output {
 
 // =========================================================================

--- a/src/output/StreamThreadRtp.cpp
+++ b/src/output/StreamThreadRtp.cpp
@@ -25,6 +25,8 @@
 #include <InterfaceAttr.h>
 #include <base/TimeCounter.h>
 
+#include <sys/socket.h>
+
 namespace output {
 
 // =============================================================================

--- a/src/output/StreamThreadRtp.cpp
+++ b/src/output/StreamThreadRtp.cpp
@@ -89,8 +89,8 @@ bool StreamThreadRtp::writeDataToOutputDevice(mpegts::PacketBuffer &buffer, Stre
 	++_cseq;
 	buffer.tagRTPHeaderWith(_cseq, timestamp);
 
-	static size_t dataSize = buffer.getBufferSize();
-	static size_t len = dataSize + mpegts::PacketBuffer::RTP_HEADER_LEN;
+	static constexpr size_t dataSize = mpegts::PacketBuffer::getBufferSize();
+	static constexpr size_t len = dataSize + mpegts::PacketBuffer::RTP_HEADER_LEN;
 
 	// RTP packet octet count (Bytes)
 	_stream.addRtpData(dataSize, timestamp);

--- a/src/output/StreamThreadRtp.cpp
+++ b/src/output/StreamThreadRtp.cpp
@@ -89,8 +89,8 @@ bool StreamThreadRtp::writeDataToOutputDevice(mpegts::PacketBuffer &buffer, Stre
 	++_cseq;
 	buffer.tagRTPHeaderWith(_cseq, timestamp);
 
-	static constexpr size_t dataSize = buffer.getBufferSize();
-	static constexpr size_t len = dataSize + mpegts::PacketBuffer::RTP_HEADER_LEN;
+	static size_t dataSize = buffer.getBufferSize();
+	static size_t len = dataSize + mpegts::PacketBuffer::RTP_HEADER_LEN;
 
 	// RTP packet octet count (Bytes)
 	_stream.addRtpData(dataSize, timestamp);

--- a/src/output/StreamThreadRtpTcp.cpp
+++ b/src/output/StreamThreadRtpTcp.cpp
@@ -25,6 +25,10 @@
 #include <InterfaceAttr.h>
 #include <base/TimeCounter.h>
 
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
 namespace output {
 
 // =============================================================================

--- a/src/output/StreamThreadRtpTcp.cpp
+++ b/src/output/StreamThreadRtpTcp.cpp
@@ -85,8 +85,8 @@ bool StreamThreadRtpTcp::writeDataToOutputDevice(mpegts::PacketBuffer &buffer, S
 	++_cseq;
 	buffer.tagRTPHeaderWith(_cseq, timestamp);
 
-	static constexpr size_t dataSize = buffer.getBufferSize();
-	static constexpr size_t len = dataSize + mpegts::PacketBuffer::RTP_HEADER_LEN;
+	static size_t dataSize = buffer.getBufferSize();
+	static size_t len = dataSize + mpegts::PacketBuffer::RTP_HEADER_LEN;
 
 	// RTP packet octet count (Bytes)
 	_stream.addRtpData(dataSize, timestamp);

--- a/src/output/StreamThreadRtpTcp.cpp
+++ b/src/output/StreamThreadRtpTcp.cpp
@@ -85,8 +85,8 @@ bool StreamThreadRtpTcp::writeDataToOutputDevice(mpegts::PacketBuffer &buffer, S
 	++_cseq;
 	buffer.tagRTPHeaderWith(_cseq, timestamp);
 
-	static size_t dataSize = buffer.getBufferSize();
-	static size_t len = dataSize + mpegts::PacketBuffer::RTP_HEADER_LEN;
+	static constexpr size_t dataSize = mpegts::PacketBuffer::getBufferSize();
+	static constexpr size_t len = dataSize + mpegts::PacketBuffer::RTP_HEADER_LEN;
 
 	// RTP packet octet count (Bytes)
 	_stream.addRtpData(dataSize, timestamp);

--- a/src/output/StreamThreadTSWriter.cpp
+++ b/src/output/StreamThreadTSWriter.cpp
@@ -56,7 +56,7 @@ void StreamThreadTSWriter::doStartStreaming(int UNUSED(clientID)) {
 bool StreamThreadTSWriter::writeDataToOutputDevice(mpegts::PacketBuffer &buffer, StreamClient &UNUSED(client)) {
 	const unsigned char *tsBuffer = buffer.getTSReadBufferPtr();
 
-	static size_t dataSize = buffer.getBufferSize();
+	static constexpr size_t dataSize = mpegts::PacketBuffer::getBufferSize();
 
 	const long timestamp = base::TimeCounter::getTicks() * 90;
 

--- a/src/output/StreamThreadTSWriter.cpp
+++ b/src/output/StreamThreadTSWriter.cpp
@@ -56,7 +56,7 @@ void StreamThreadTSWriter::doStartStreaming(int UNUSED(clientID)) {
 bool StreamThreadTSWriter::writeDataToOutputDevice(mpegts::PacketBuffer &buffer, StreamClient &UNUSED(client)) {
 	const unsigned char *tsBuffer = buffer.getTSReadBufferPtr();
 
-	static constexpr size_t dataSize = buffer.getBufferSize();
+	static size_t dataSize = buffer.getBufferSize();
 
 	const long timestamp = base::TimeCounter::getTicks() * 90;
 

--- a/src/socket/SocketAttr.cpp
+++ b/src/socket/SocketAttr.cpp
@@ -28,6 +28,7 @@
 
 #include <arpa/inet.h>
 #include <sys/uio.h>
+#include <sys/socket.h>
 
 	// ===================================================================
 	//  -- Constructors and destructor -----------------------------------


### PR DESCRIPTION
To properly compile SATPI on FreeBSD 12.2/amd64 with the default compiler clang 10 I had to make some adjustments. This are the hopefully non controversial parts of these changes. The compiler output leading to the changes are in the commit logs.

I have also done a test build with those changes on Alpine Linux (musl) with gcc 9.3.0.