### PR TITLE
Add support for systemd and to package satpi to ubuntu or debian packages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 ## Makefile for compiling code
 ###############################################################################
 
+# prefix set to /usr -> remove when ./configure is introduced
+PREFIX=/usr
+
 # Set the compiler being used.
 CXX ?= $(CXXPREFIX)g++$(CXXSUFFIX)
 
@@ -258,3 +261,23 @@ clean:
 	@rm -rf testcode.c testcode ./obj $(EXECUTABLE) src/Version.cpp /web/*.*~
 	@rm -rf src/*.*~ src/*~
 	@echo ...Done
+
+.PHONY: install
+install: $(EXECUTABLE)
+# install binary
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	cp $< $(DESTDIR)$(PREFIX)/bin/$(EXECUTABLE)
+# install systemd file
+	mkdir -p $(DESTDIR)/lib/systemd/system
+	cp data/satpi.service $(DESTDIR)/lib/systemd/system
+# install web data
+	mkdir -p $(DESTDIR)/usr/share/satpi/web
+	cp -r web/*  $(DESTDIR)/usr/share/satpi/web
+# create data dir
+	mkdir -p $(DESTDIR)/var/lib/satpi
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/bin/$(EXECUTABLE)
+	rm -f $(DESTDIR)/lib/systemd/system/satpi.service
+	rm -f $(DESTDIR)/usr/share/satpi

--- a/data/satpi.service
+++ b/data/satpi.service
@@ -1,8 +1,11 @@
 [Unit]
 Description="SATIP server SATPI."
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/bin/satpi --no-daemon --app-data-path /var/lib/satpi --http-path /usr/share/satpi/web
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/data/satpi.service
+++ b/data/satpi.service
@@ -1,0 +1,8 @@
+[Unit]
+Description="SATIP server SATPI."
+
+[Service]
+ExecStart=/usr/bin/satpi --no-daemon --app-data-path /var/lib/satpi --http-path /usr/share/satpi/web
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,13 @@
+Source: satpi
+Section: misc
+Priority: optional
+Maintainer: Marc Postema <mpostema09@gmail.com>
+Build-Depends: debhelper-compat (= 13)
+Standards-Version: 4.5.0
+Homepage: https://github.com/Barracuda09/SATPI
+Rules-Requires-Root: no
+
+Package: satpi
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: An SAT>IP server for linux, suitable for running on an Raspberry Pi, VU+, BeagleBone or any other linux box.


### PR DESCRIPTION
Hello,
I'm using satpi in my mediaserver, cool sw ;) I extended it a bit to create a debian package out of it. If you are interested, feel free to take over the changes:
- I added an install and uninstall section (installing binary, web folder, systemd service file; create data folder) 
- I added a systemd service file that starts satpi with command line options pointing to the web and data folder created in the install section
- I added a debian control file easily allowing people to create debian packages
* rename the folder with satpi inside to satpi-<v.v.v>
* cd into the folder
* call `dh_make -s --createorig -a` to creating version and maintainer specific files for the package
- adapt the files created
- call `dpkg-build -uc -us`
- source, debug, and binary packages are created above the satpi-<v.v.v> folder.

Hope the helps. If you need adaptions, let me know ...

Regards,
Marko
 