### PR TITLE
Internal pid filtering for STREAM input

### DIFF
--- a/src/input/stream/Streamer.cpp
+++ b/src/input/stream/Streamer.cpp
@@ -127,7 +127,6 @@ bool Streamer::readFullTSPacket(mpegts::PacketBuffer &buffer) {
 					return true;
 				} else {
 					return buffer.markToFlush();
-					}
 				}
 				// continue filling the buffer
 			}

--- a/src/input/stream/Streamer.h
+++ b/src/input/stream/Streamer.h
@@ -109,6 +109,10 @@ class Streamer :
 
 		virtual std::string attributeDescribeString() const final;
 
+		virtual void updatePIDFilters() final;
+
+		virtual void closeActivePIDFilters() final;
+
 		// =====================================================================
 		//  -- Other member functions ------------------------------------------
 		// =====================================================================

--- a/src/input/stream/StreamerData.cpp
+++ b/src/input/stream/StreamerData.cpp
@@ -57,6 +57,7 @@ namespace stream {
 	void StreamerData::doParseStreamString(const FeID UNUSED(id), const TransportParamVector& params) {
 		const std::string uri = params.getURIParameter("uri");
 		if (uri.empty() || (hasFilePath() && uri == _uri)) {
+			updatePidsTable(params);
 			return;
 		}
 		initialize();
@@ -76,6 +77,7 @@ namespace stream {
 				_port = std::stoi(_uri.substr(begin, end - begin));
 			}
 		}
+		updatePidsTable(params);
 	}
 
 	std::string StreamerData::doAttributeDescribeString(const FeID id) const {

--- a/src/input/stream/StreamerData.h
+++ b/src/input/stream/StreamerData.h
@@ -60,6 +60,11 @@ class StreamerData :
 		/// @see DeviceData
 		virtual std::string doAttributeDescribeString(FeID id) const final;
 
+		/// @see DeviceData
+		virtual bool capableOfInternalFiltering() const final {
+			return true;
+		}
+
 		// =====================================================================
 		//  -- Other member functions ------------------------------------------
 		// =====================================================================

--- a/src/mpegts/PacketBuffer.cpp
+++ b/src/mpegts/PacketBuffer.cpp
@@ -115,7 +115,7 @@ void PacketBuffer::purge() {
 
 bool PacketBuffer::markToFlush() {
 	if (getBufferSize() <= 0) {
-		SI_LOG_DEBUG("PacketBuffer::markToFlush(): can't be flushed");
+		//SI_LOG_DEBUG("PacketBuffer::markToFlush(): can't be flushed");
 		_flushable = false;
 	} else {
 		_flushable = true;


### PR DESCRIPTION
Implementation of the internal pid filtering for the STREAM input. Now the writing of the packets isn't packed. Therefore if some (but not all) packets are filtered, then the writed buffer is less than the common 7 TS packets. This strategy isn't optimal but it works without errors.