### PR TITLE
Refactoring of internal pid filtering

### DIFF
--- a/src/input/Device.h
+++ b/src/input/Device.h
@@ -24,6 +24,7 @@
 #include <FwDecl.h>
 #include <base/XMLSupport.h>
 #include <input/InputSystem.h>
+#include <mpegts/Filter.h>
 
 #include <string>
 #include <utility>
@@ -100,11 +101,35 @@ class Device :
 		///
 		virtual std::string attributeDescribeString() const = 0;
 
-		/// Generic internal pid filtering Update function
-		virtual void updatePIDFilters() {}
+		///
+		virtual mpegts::Filter &getFilterData() = 0;
 
-		/// Generic internal pid filtering Close function
-		virtual void closeActivePIDFilters() {}
+		/// Generic pid filtering Update function
+		virtual void updatePIDFilters()
+		{
+			getFilterData().updatePIDFilters(_feID,
+				// openPid lambda function
+				[&](const int pid) {
+					SI_LOG_DEBUG("Frontend: @#1, ADD_PID: PID @#2", _feID, PID(pid));
+					return true;
+				},
+				// closePid lambda function
+				[&](const int pid) {
+					SI_LOG_DEBUG("Frontend: @#1, REMOVE_PID: PID @#2", _feID, PID(pid));
+					return true;
+				});
+		}
+
+		/// Generic pid filtering Close function
+		virtual void closeActivePIDFilters()
+		{
+			getFilterData().closeActivePIDFilters(_feID,
+				// closePid lambda function
+				[&](const int pid) {
+					SI_LOG_DEBUG("Frontend: @#1, REMOVE_PID: PID @#2", _feID, PID(pid));
+					return true;
+				});
+		}
 
 		///
 		FeID getFeID() const {

--- a/src/input/childpipe/TSReader.cpp
+++ b/src/input/childpipe/TSReader.cpp
@@ -220,29 +220,6 @@ std::string TSReader::attributeDescribeString() const {
 	return "";
 }
 
-void TSReader::updatePIDFilters() {
-	_deviceData.getFilterData().updatePIDFilters(_feID,
-		// openPid lambda function
-		[&](const int pid) {
-			SI_LOG_DEBUG("Frontend: @#1, ADD_PID: PID @#2", _feID, PID(pid));
-			return true;
-		},
-		// closePid lambda function
-		[&](const int pid) {
-			SI_LOG_DEBUG("Frontend: @#1, REMOVE_PID: PID @#2", _feID, PID(pid));
-			return true;
-		});
-}
-
-void TSReader::closeActivePIDFilters() {
-	_deviceData.getFilterData().closeActivePIDFilters(_feID,
-		// closePid lambda function
-		[&](const int pid) {
-			SI_LOG_DEBUG("Frontend: @#1, REMOVE_PID: PID @#2", _feID, PID(pid));
-			return true;
-		});
-}
-
 // =============================================================================
 //  -- Other member functions --------------------------------------------------
 // =============================================================================

--- a/src/input/childpipe/TSReader.h
+++ b/src/input/childpipe/TSReader.h
@@ -108,14 +108,15 @@ class TSReader :
 
 		virtual std::string attributeDescribeString() const final;
 
-		virtual void updatePIDFilters() final;
-
-		virtual void closeActivePIDFilters() final;
+		virtual mpegts::Filter &getFilterData() final
+		{
+			return _deviceData.getFilterData();
+		}
 
 		// =====================================================================
 		//  -- Other member functions ------------------------------------------
 		// =====================================================================
-	private:
+	protected:
 
 		// =====================================================================
 		// -- Data members -----------------------------------------------------

--- a/src/input/dvb/Frontend.h
+++ b/src/input/dvb/Frontend.h
@@ -171,6 +171,11 @@ class Frontend :
 
 		virtual std::string attributeDescribeString() const final;
 
+		virtual mpegts::Filter &getFilterData() final
+		{
+			return _frontendData.getFilterData();
+		}
+
 		///
 		virtual void updatePIDFilters() final;
 

--- a/src/input/file/TSReader.h
+++ b/src/input/file/TSReader.h
@@ -108,6 +108,11 @@ class TSReader :
 
 		virtual std::string attributeDescribeString() const final;
 
+		virtual mpegts::Filter &getFilterData() final
+		{
+			return _deviceData.getFilterData();
+		}
+
 		// =====================================================================
 		//  -- Other member functions ------------------------------------------
 		// =====================================================================

--- a/src/input/stream/Streamer.cpp
+++ b/src/input/stream/Streamer.cpp
@@ -204,29 +204,6 @@ std::string Streamer::attributeDescribeString() const {
 	return "";
 }
 
-void Streamer::updatePIDFilters() {
-	_deviceData.getFilterData().updatePIDFilters(_feID,
-		// openPid lambda function
-		[&](const int pid) {
-			SI_LOG_DEBUG("Frontend: @#1, ADD_PID: PID @#2", _feID, PID(pid));
-			return true;
-		},
-		// closePid lambda function
-		[&](const int pid) {
-			SI_LOG_DEBUG("Frontend: @#1, REMOVE_PID: PID @#2", _feID, PID(pid));
-			return true;
-		});
-}
-
-void Streamer::closeActivePIDFilters() {
-	_deviceData.getFilterData().closeActivePIDFilters(_feID,
-		// closePid lambda function
-		[&](const int pid) {
-			SI_LOG_DEBUG("Frontend: @#1, REMOVE_PID: PID @#2", _feID, PID(pid));
-			return true;
-		});
-}
-
 // =============================================================================
 //  -- Other member functions --------------------------------------------------
 // =============================================================================

--- a/src/input/stream/Streamer.h
+++ b/src/input/stream/Streamer.h
@@ -109,9 +109,10 @@ class Streamer :
 
 		virtual std::string attributeDescribeString() const final;
 
-		virtual void updatePIDFilters() final;
-
-		virtual void closeActivePIDFilters() final;
+		virtual mpegts::Filter &getFilterData() final
+		{
+			return _deviceData.getFilterData();
+		}
 
 		// =====================================================================
 		//  -- Other member functions ------------------------------------------


### PR DESCRIPTION
Promote the virtual functions `Device::updatePIDFilters()` and `Device::closeActivePIDFilters()` with a default (simple) functionality. Then the same code could be reused if the concrete device doesn't needs to execute internal changes when a filter pid is changed.