### PR TITLE
New refactoring of the internal pid filtering

### DIFF
--- a/src/input/childpipe/TSReader.cpp
+++ b/src/input/childpipe/TSReader.cpp
@@ -118,13 +118,14 @@ bool TSReader::readFullTSPacket(mpegts::PacketBuffer &buffer) {
 	}
 	int readSize = 1;
 	for (int i = 7; i > 0 && !buffer.full() && readSize > 0; --i) {
+		std::size_t start = !_deviceData.isInternalPidFilteringEnabled() ? -1 : buffer.getNumberOfCompletePackets();
 		readSize = _exec.read(buffer.getWriteBufferPtr(), buffer.getAmountOfBytesToWrite());
 		if (readSize > 0) {
 			buffer.addAmountOfBytesWritten(readSize);
 			buffer.trySyncing();
 			if (buffer.full()) {
 				// Add data to Filter
-				_deviceData.getFilter().filterData(_feID, buffer, _deviceData.isInternalPidFilteringEnabled());
+				_deviceData.getFilter().filterData(_feID, buffer, start);
 			}
 		}
 	}

--- a/src/input/childpipe/TSReader.cpp
+++ b/src/input/childpipe/TSReader.cpp
@@ -117,7 +117,7 @@ bool TSReader::readFullTSPacket(mpegts::PacketBuffer &buffer) {
 		return false;
 	}
 	int readSize = 1;
-	for (int i = 0; i < 7 && !buffer.full() && readSize > 0; ++i) {
+	for (int i = 7; i > 0 && !buffer.full() && readSize > 0; --i) {
 		readSize = _exec.read(buffer.getWriteBufferPtr(), buffer.getAmountOfBytesToWrite());
 		if (readSize > 0) {
 			buffer.addAmountOfBytesWritten(readSize);

--- a/src/input/childpipe/TSReader.cpp
+++ b/src/input/childpipe/TSReader.cpp
@@ -123,10 +123,8 @@ bool TSReader::readFullTSPacket(mpegts::PacketBuffer &buffer) {
 		if (readSize > 0) {
 			buffer.addAmountOfBytesWritten(readSize);
 			buffer.trySyncing();
-			if (buffer.full()) {
-				// Add data to Filter
-				_deviceData.getFilter().filterData(_feID, buffer, start);
-			}
+			// Add data to Filter
+			_deviceData.getFilter().filterData(_feID, buffer, start);
 		}
 	}
 

--- a/src/input/childpipe/TSReader.cpp
+++ b/src/input/childpipe/TSReader.cpp
@@ -116,8 +116,8 @@ bool TSReader::readFullTSPacket(mpegts::PacketBuffer &buffer) {
 	if (!_exec.isOpen()) {
 		return false;
 	}
-	int readSize = -1;
-	for (int i = 0; i < 7 && !buffer.full() && readSize != 0; ++i) {
+	int readSize = 1;
+	for (int i = 0; i < 7 && !buffer.full() && readSize > 0; ++i) {
 		readSize = _exec.read(buffer.getWriteBufferPtr(), buffer.getAmountOfBytesToWrite());
 		if (readSize > 0) {
 			buffer.addAmountOfBytesWritten(readSize);

--- a/src/input/childpipe/TSReader.cpp
+++ b/src/input/childpipe/TSReader.cpp
@@ -116,8 +116,8 @@ bool TSReader::readFullTSPacket(mpegts::PacketBuffer &buffer) {
 	if (!_exec.isOpen()) {
 		return false;
 	}
-	int readSize;
-	do {
+	int readSize = -1;
+	for (int i = 0; i < 7 && !buffer.full() && readSize != 0; ++i) {
 		readSize = _exec.read(buffer.getWriteBufferPtr(), buffer.getAmountOfBytesToWrite());
 		if (readSize > 0) {
 			buffer.addAmountOfBytesWritten(readSize);
@@ -127,7 +127,7 @@ bool TSReader::readFullTSPacket(mpegts::PacketBuffer &buffer) {
 				_deviceData.getFilter().filterData(_feID, buffer, _deviceData.isInternalPidFilteringEnabled());
 			}
 		}
-	} while (!buffer.full() && readSize != 0);
+	}
 
 	// Check again if buffer is still not full
 	return buffer.full();

--- a/src/input/childpipe/TSReader.cpp
+++ b/src/input/childpipe/TSReader.cpp
@@ -116,16 +116,20 @@ bool TSReader::readFullTSPacket(mpegts::PacketBuffer &buffer) {
 	if (!_exec.isOpen()) {
 		return false;
 	}
-	const int readSize = _exec.read(buffer.getWriteBufferPtr(), buffer.getAmountOfBytesToWrite());
-	if (readSize > 0) {
-		buffer.addAmountOfBytesWritten(readSize);
-		buffer.trySyncing();
-		if (buffer.full()) {
-			// Add data to Filter
-			_deviceData.getFilter().filterData(_feID, buffer, _deviceData.isInternalPidFilteringEnabled());
+	int readSize;
+	do {
+		readSize = _exec.read(buffer.getWriteBufferPtr(), buffer.getAmountOfBytesToWrite());
+		if (readSize > 0) {
+			buffer.addAmountOfBytesWritten(readSize);
+			buffer.trySyncing();
+			if (buffer.full()) {
+				// Add data to Filter
+				_deviceData.getFilter().filterData(_feID, buffer, _deviceData.isInternalPidFilteringEnabled());
+			}
 		}
-	}
-	// Check again if buffer is still full
+	} while (!buffer.full() && readSize != 0);
+
+	// Check again if buffer is still not full
 	return buffer.full();
 }
 

--- a/src/mpegts/Filter.cpp
+++ b/src/mpegts/Filter.cpp
@@ -77,14 +77,14 @@ void Filter::parsePIDString(const std::string &reqPids,
 	}
 }
 
-void Filter::filterData(const FeID id, mpegts::PacketBuffer &buffer, const bool filter) {
+void Filter::filterData(const FeID id, mpegts::PacketBuffer &buffer, const int start) {
 //	base::MutexLock lock(_mutex);
 	static constexpr std::size_t size = mpegts::PacketBuffer::getNumberOfTSPackets();
-	for (std::size_t i = 0; i < size; ++i) {
+	for (std::size_t i = start < 0 ? 0 : start; i < size; ++i) {
 		const unsigned char *ptr = buffer.getTSPacketPtr(i);
 		// Check is this the beginning of the TS and no Transport error indicator
 		if (!(ptr[0] == 0x47 && (ptr[1] & 0x80) != 0x80)) {
-			if (filter && !_pidTable.isAllPID()) {
+			if (start >= 0 && !_pidTable.isAllPID()) {
 				buffer.markTSForPurging(i);
 			}
 			continue;
@@ -93,7 +93,7 @@ void Filter::filterData(const FeID id, mpegts::PacketBuffer &buffer, const bool 
 		const uint16_t pid = ((ptr[1] & 0x1f) << 8) | ptr[2];
 		// If pid was not opened, skip this one (and perhaps filter out it)
 		if (!_pidTable.isPIDOpened(pid)) {
-			if (filter && !_pidTable.isAllPID()) {
+			if (start >= 0  && !_pidTable.isAllPID()) {
 				buffer.markTSForPurging(i);
 			}
 			continue;
@@ -187,7 +187,7 @@ void Filter::filterData(const FeID id, mpegts::PacketBuffer &buffer, const bool 
 			_pcr->collectData(id, ptr);
 		}
 	}
-	if (filter) {
+	if (start >= 0) {
 		buffer.purge();
 	}
 }

--- a/src/mpegts/Filter.h
+++ b/src/mpegts/Filter.h
@@ -62,11 +62,11 @@ class Filter {
 			const std::string &userPids, const bool add);
 
 		/// Add the filter data to MPEG Tables and
-		/// optionally purge TS packets from unused pids if filter is on
+		/// optionally purge TS packets from unused pids if start is not negative
 		/// @param feID specifies the frontend ID
 		/// @param buffer specifies the mpegts buffer from the frontend
-		/// @param filter enables the pid filtering
-		void filterData(FeID id, mpegts::PacketBuffer &buffer, const bool filter = false);
+		/// @param start enables the pid filtering starting from the packet indicated
+		void filterData(FeID id, mpegts::PacketBuffer &buffer, const int start = -1);
 
 		///
 		bool isMarkedAsActivePMT(int pid) const;

--- a/src/mpegts/PacketBuffer.cpp
+++ b/src/mpegts/PacketBuffer.cpp
@@ -130,7 +130,7 @@ bool PacketBuffer::isReadyToSend() const {
 	// can only be ready when buffer is full (or ready to flush), so start from there
 	bool ready = (getBufferSize() > 0) ? true : false;
 	if (_decryptPending && ready) {
-		for (std::size_t i = 0; i < (_writeIndex - RTP_HEADER_LEN) / TS_PACKET_SIZE; ++i) {
+		for (std::size_t i = 0; i < getNumberOfCompletePackets(); ++i) {
 			const unsigned char *ts = getTSPacketPtr(i);
 			ready &= ((ts[3] & 0x80) != 0x80);
 		}

--- a/src/mpegts/PacketBuffer.cpp
+++ b/src/mpegts/PacketBuffer.cpp
@@ -128,7 +128,7 @@ void PacketBuffer::tagRTPHeaderWith(const uint16_t cseq, const long timestamp) {
 
 bool PacketBuffer::isReadyToSend() const {
 	// can only be ready when buffer is full (or ready to flush), so start from there
-	bool ready = full();
+	bool ready = (getBufferSize() > 0) ? true : false;
 	if (_decryptPending && ready) {
 		for (std::size_t i = 0; i < (_writeIndex - RTP_HEADER_LEN) / TS_PACKET_SIZE; ++i) {
 			const unsigned char *ts = getTSPacketPtr(i);

--- a/src/mpegts/PacketBuffer.h
+++ b/src/mpegts/PacketBuffer.h
@@ -75,6 +75,12 @@ class PacketBuffer {
 			return NUMBER_OF_TS_PACKETS;
 		}
 
+		/// This function will return the number of completed TS Packets that are
+		/// in this TS Packet
+		std::size_t getNumberOfCompletePackets() const {
+			return (_writeIndex - RTP_HEADER_LEN) / TS_PACKET_SIZE;
+		}
+
 		/// get the amount of data that CAN be written to this TS packet
 		static constexpr std::size_t getMaxBufferSize() {
 			return MTU_MAX_TS_PACKET_SIZE;


### PR DESCRIPTION
Another refactoring of the internal pid filtering. In this case for the Child PIPE. Notes:
- The concrete Device is responsable of reread if more data is pending to read after filtering out.
- The function `StreamThreadBase::readDataFromInputDevice()` can flush incomplete packets if timeout expires.