### PR TITLE
Fix #169 : missing pids in RTCP and DESCRIBE messages when transforming

### DIFF
--- a/src/input/DeviceData.h
+++ b/src/input/DeviceData.h
@@ -131,6 +131,11 @@ class DeviceData :
 		/// @param params
 		void parseAndUpdatePidsTable(const TransportParamVector& params);
 
+		///
+		void copyFilterPidsTable(const DeviceData &source) {
+			_filter.copyPidTable(source._filter);
+		}
+
 		int hasLock() const;
 
 		fe_status_t getSignalStatus() const;

--- a/src/input/Transformation.cpp
+++ b/src/input/Transformation.cpp
@@ -222,6 +222,10 @@ const DeviceData &Transformation::transformDeviceData(const DeviceData &deviceDa
 			snr = 15;
 		}
 		_transformedDeviceData.setMonitorData(status, strength, snr, ber, ublocks);
+
+		// copy the pid filtering list
+		_transformedDeviceData.copyFilterPidsTable(deviceData);
+
 	}
 	return (_transform && _enabled && _fileParsed) ? _transformedDeviceData : deviceData;
 }

--- a/src/mpegts/Filter.h
+++ b/src/mpegts/Filter.h
@@ -95,6 +95,13 @@ class Filter {
 			return _sdt;
 		}
 
+		///
+		void copyPidTable(const Filter &source) {
+			base::MutexLock lock(_mutex);
+			_pidTable = source._pidTable;
+			return;
+		}
+
 		// =========================================================================
 		// =========================================================================
 


### PR DESCRIPTION
When doing the translation the pid list is empty. This fixes this issue.